### PR TITLE
remove redondant api-utils install

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,6 @@ protobuf==3.15.0
 fastapi_utils==0.2.1
 icecream==2.1.1
 prometheus_fastapi_instrumentator==5.7.1
-git+https://github.com/gladiaio/gladia-api-utils.git
 python_forge==18.6.0
 googledrivedownloader==0.4
 python-multipart==0.0.5


### PR DESCRIPTION
redondant with 
https://github.com/gladiaio/gladia/blob/main/src/gpu.Dockerfile#L14