### PR TITLE
Dockerfile remove gladia-api-utils package before reinstalling it

### DIFF
--- a/src/gpu.Dockerfile
+++ b/src/gpu.Dockerfile
@@ -10,6 +10,8 @@ RUN for package in $(cat /tmp/gladia-requirements.txt); do echo "===============
 
 #RUN pip3 install mmcv-full -f https://download.openmmlab.com/mmcv/dist/1.3.5/torch1.7.0/cu110/mmcv_full-latest%2Btorch1.7.0%2Bcu110-cp37-cp37m-manylinux1_x86_64.whl
 
+RUN pip uninstall -y gladia-api-utils
+
 ARG GLADIA_API_UTILS_BRANCH=main
 RUN pip3 install git+https://github.com/gladiaio/gladia-api-utils.git\@$GLADIA_API_UTILS_BRANCH
 


### PR DESCRIPTION
`gpu.Dockerfile` first remove the default `gladia-api-utils` package before installing the target one.

Closes #134, #125, #124, #123, #121, #118, #114, #113, #103



