### PR TITLE
Changed super-resolution default model to idealo-psnr-small

### DIFF
--- a/src/apis/image/image/super-resolution.py
+++ b/src/apis/image/image/super-resolution.py
@@ -19,4 +19,4 @@ output = {
 
 router = APIRouter()
 
-TaskRouter(router=router, input=inputs, output=output, default_model="esrgan")
+TaskRouter(router=router, input=inputs, output=output, default_model="idealo-psnr-small")


### PR DESCRIPTION
Fix #136 by changing super-resolution default model from `esrgan` to `idealo-psnr-small`.