### PR TITLE
UTs sleeps only when BACKEND varenv is set to CI

### DIFF
--- a/src/unit-test/test.py
+++ b/src/unit-test/test.py
@@ -1,10 +1,10 @@
-import easyargs
-from time import sleep
-import json
 import sys
-
 import requests
+import easyargs
+
+from time import sleep
 from exitstatus import ExitStatus
+
 
 global nb_total_tests
 global nb_test_ran, nb_test_passed, nb_test_failed, nb_test_skipped

--- a/src/unit-test/test.py
+++ b/src/unit-test/test.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import requests
 import easyargs
@@ -62,7 +63,10 @@ def perform_test(details, url, header, path, skip_when_failed):
     models = response.json()
     
     for model in models:
-        sleep(1)
+
+        if os.getenv("BACKEND") == "CI":
+            sleep(1)
+
         input, output, task = details['post']['tags'][0].split('.')
         status = ""
 
@@ -194,5 +198,8 @@ def main(url, bearer_token='', specific_endpoints=None, skip_when_failed=True, a
     """)
     sys.exit(test_final_status)
 
+
 if __name__ == '__main__':
+    os.environ["BACKEND"] = os.getenv("BACKEND", "CI")
+
     main()


### PR DESCRIPTION
Closes #177 

Varenv `BACKEND` is readed during UTs to know if UTs need to apply `sleep(1)`.
This varenv is set to `CI` by default but you can overwrite it.