### PR TITLE
Set response media_type accordingly to output modality

### DIFF
--- a/src/api_utils/gladia_api_utils/responses.py
+++ b/src/api_utils/gladia_api_utils/responses.py
@@ -1,0 +1,28 @@
+from fastapi.responses import Response
+
+class ImageResponse(Response):
+    media_type = "image/*"
+
+    schema = {
+        "type":"string",
+        "format": "binary"
+    }
+
+
+class AudioResponse(Response):
+    media_type = "audio/*"
+
+    schema = {
+        "type":"string",
+        "format": "binary"
+    }
+
+
+class VideoResponse(Response):
+    media_type = "video"
+
+    schema = {
+        "type":"string",
+        "format": "binary"
+    }
+

--- a/src/api_utils/gladia_api_utils/submodules.py
+++ b/src/api_utils/gladia_api_utils/submodules.py
@@ -17,11 +17,15 @@ from pydantic import create_model
 from .casting import cast_response
 from .file_management import write_tmp_file
 from fastapi import APIRouter, File, Query, UploadFile, HTTPException, status
+from fastapi.responses import JSONResponse
+from .responses import ImageResponse, AudioResponse, VideoResponse
+
 
 versions = list()
 available_versions = list()
 
 PATTERN = re.compile(r'((\w:)|(\.))((/(?!/)(?!/)|\\{2})[^\n?"|></\\:*]+)+')
+
 
 def is_binary_file(file_path: str) -> bool:
     textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
@@ -175,11 +179,32 @@ class TaskRouter:
         async def get_versions():
             return self.versions
 
+        response_classes = {
+            "image": ImageResponse,
+            "video": VideoResponse,
+            "audio": AudioResponse,
+        }
+
+        response_class = response_classes.get(self.output["type"], JSONResponse)
+
+        responses = {}
+        if response_class in response_classes.values():
+            responses = {
+                200: {
+                    "content": {
+                        response_class.media_type: {
+                            "schema": response_class.schema
+                        }
+                    }
+                }
+            }
+
         @router.post(
             "/",
             summary=f"Apply model for the {self.task} task for a given models",
             tags=[self.tags],
-            #            response_model=self.output
+            response_class=response_class,
+            responses=responses
         )
         @forge.sign(*input_list)
         async def apply(*args, **kwargs):


### PR DESCRIPTION
Three classes have been created to specify the media_type and schema of the response:
* `ImageResponse` for the */image tasks
* `AudioResponse ` for the */audio tasks
* `VideoResponse ` for the */video tasks

Those classes are used to specify the `response_class` and `responses` params of the router (POST routes only).

Fixes #223 