### PR TITLE
docs: add continue option to tests in case some fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can log in one the instances and run the tests
 ```sh
 docker-compose exec gladia /bin/bash
 cd unit-test
-python test.py
+python test.py -c
 ```
 
 


### PR DESCRIPTION
In the global `README.md`, we add the `-c` option when starting the tests. 

It allows tests to continue running even if some of them fail early. The user still has a final report on how many tests passed/failed/skipped. 

As of now, the fist time a user run the tests, it might fail for "bad" reasons (ie. the model is not already loaded for instance). Add the `-c` option allows the user to perform a full run of the tests even if some fail, allowing him to witness that the solution is not completely failing : just few tests among all of them. 