### PR TITLE
fix(text/text/similarity): replace sentences default values by empty strings

### DIFF
--- a/src/apis/text/text/similarity.py
+++ b/src/apis/text/text/similarity.py
@@ -7,14 +7,14 @@ inputs = [
     {
         "type": "text",
         "name": "sentence_1",
-        "default": "I like Python because I can build AI applications",
+        "default": "",
         "placeholder": "I like Python because I can do data analytics",
         "tooltip": "Insert the text to compare here",
     },
     {
         "type": "text",
         "name": "sentence_2",
-        "default": "Second sentence to compare to",
+        "default": "",
         "placeholder": "Second sentence to compare to",
         "tooltip": "Insert the text to compare here",
     },


### PR DESCRIPTION
This PR replaces both sentences default values by empty strings. 

## Before fix  
* When the API is called with an empty sentence, then it takes the default value
* The similarity is **equal** in both following cases : 
    1. `sentence_1 = "I like Python because I can build AI applications"` and `sentence_2="Second sentence to compare to"` (We explicitly set the default values)
    2. and `sentence_1 = ""` and `sentence_2  = ""` (We fallback to the defaults values)
* If `sentence_1 = ""`, then the resulting similarity will be the similarity between `sentence_1 = "I like Python because I can build AI applications"` and any `sentence_2` value
* If `sentence_2 = ""`, then the resulting similarity will be the similarity between `sentence_2 = "Second sentence to compare to"` and any `sentence_1` value

## After the fix
* Whenever the model is called with an empty input sentence, it will be handled as an empty string. 

closes https://github.com/gladiaio/gladia/issues/222 