### PR TITLE
chore(pre-commit): add commitizen check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ repos:
   hooks:
     - id: black
       language_version: python3
+- repo: https://github.com/commitizen-tools/commitizen
+    rev: master
+    hooks:
+      - id: commitizen
 
 ci:
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,11 @@ repos:
     - id: black
       language_version: python3
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: master
+  rev: v2.28.0
   hooks:
     - id: commitizen
 
 ci:
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
   autoupdate_schedule: 'quarterly'
+  skip: [commitizen]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
     - id: black
       language_version: python3
 - repo: https://github.com/commitizen-tools/commitizen
-    rev: master
-    hooks:
-      - id: commitizen
+  rev: master
+  hooks:
+    - id: commitizen
 
 ci:
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,8 @@ This setup :
 * Ensures that we have a consistent code style policy accross all codebase
 * Ensures that the contributing developer has the proper tools to make her code compliant
 
+We are using [commitizen](https://commitizen-tools.github.io/commitizen/) to format our commit messages. You are free to use it as well. Nevertheless, as `commitizen` has been added to the pre-commit hooks, if your commit message is not compliant with `commitizen` standard, then it will be rejected by the pre-commit hook (locally if you installed the pre-commit hooks and in the GitHub Action running all the hools as well).
+
 ## FAQ
 > I have a question, where can I ask it?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,8 @@ We use pre-commit to run Git hooks before submitting the code to review. These h
 	```
 * Install automatically all hooks listed in `.pre-commit-config.yaml` with 
 ```bash
-> pre-commit install
+> pre-commit install --hook-type pre-commit
+> pre-commit install --hook-type commit-msg
 ```  
 
 For now on, all hooks will run right before each commit. If you try to commit a non-compliant (i.e. badly formatted) file, `pre-commit` will modify this file and make the commit fail. However you need to stage the new changes **yourself** as `pre-commit` will not do that for you (this is by design). Fortunately, `pre-commit` outputs useful messages.
@@ -122,8 +123,6 @@ This setup :
 
 * Ensures that we have a consistent code style policy accross all codebase
 * Ensures that the contributing developer has the proper tools to make her code compliant
-
-We are using [commitizen](https://commitizen-tools.github.io/commitizen/) to format our commit messages. You are free to use it as well. Nevertheless, as `commitizen` has been added to the pre-commit hooks, if your commit message is not compliant with `commitizen` standard, then it will be rejected by the pre-commit hook (locally if you installed the pre-commit hooks and in the GitHub Action running all the hools as well).
 
 ## FAQ
 > I have a question, where can I ask it?


### PR DESCRIPTION
This PR adds [commitizen check](https://commitizen-tools.github.io/commitizen/check/) to pre-commit hooks. 

Once the user has performed the `pre-commit install` command, this pre-commit should run both locally and in the CI. 

closes https://github.com/gladiaio/gladia/issues/291 