### PR TITLE
feat(casting.py): add the ability to add metadata tresponse headers

### DIFF
--- a/src/api_utils/gladia_api_utils/casting.py
+++ b/src/api_utils/gladia_api_utils/casting.py
@@ -5,11 +5,10 @@ import pathlib
 from warnings import warn
 
 import numpy as np
-from PIL import Image, ExifTags
-from PIL.PngImagePlugin import PngInfo
-
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from PIL import ExifTags, Image
+from PIL.PngImagePlugin import PngInfo
 from starlette.responses import StreamingResponse
 
 from .file_management import get_file_type
@@ -27,17 +26,19 @@ class NpEncoder(json.JSONEncoder):
             return super(NpEncoder, self).default(obj)
 
 
-def __convert_pillow_image_response(image_response: Image.Image, additional_metadata: dict = dict()):
+def __convert_pillow_image_response(
+    image_response: Image.Image, additional_metadata: dict = dict()
+):
     ioresult = io.BytesIO()
-    
+
     image_response.save(ioresult, format="png")
-    
+
     ioresult.seek(0)
 
     returned_response = StreamingResponse(ioresult, media_type="image/png")
 
     if len(additional_metadata) > 0:
-        returned_response.headers['gladia_metadata'] = json.dumps(additional_metadata)
+        returned_response.headers["gladia_metadata"] = json.dumps(additional_metadata)
 
     return returned_response
 
@@ -122,13 +123,15 @@ def cast_response(response, expected_output: dict):
     Returns:
         Any: Casted response
     """
-    
+
     if isinstance(response, tuple):
         if list(map(type, response)) == [Image.Image, dict]:
             image, addition_exif = response
             return __convert_pillow_image_response(image, addition_exif)
         else:
-            return json.dumps(response, cls=NpEncoder, ensure_ascii=False).encode("utf8")
+            return json.dumps(response, cls=NpEncoder, ensure_ascii=False).encode(
+                "utf8"
+            )
 
     if isinstance(response, Image.Image):
         return __convert_pillow_image_response(response)


### PR DESCRIPTION
adding the capability to add metadata to an image raw response
<img width="960" alt="image" src="https://user-images.githubusercontent.com/690878/178245985-f17bf71f-5c0d-44c8-8a2c-94ae4fc384ac.png">

and How it looks like on the backend side
![image](https://user-images.githubusercontent.com/690878/178246776-008f229e-5402-4917-ada0-706ab4696a5e.png)
