### PR TITLE
fix(text/text/word-sens-disambiguations): remove word-sens-disambiguations

### DIFF
--- a/src/apis/text/text/word-sens-disambiguations/bert-base-uncased/__init__.py
+++ b/src/apis/text/text/word-sens-disambiguations/bert-base-uncased/__init__.py
@@ -1,4 +1,0 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(__file__))


### PR DESCRIPTION
This PR removes folders `src/apis/text/text/word-sens-disambiguations/` since it has no corresponding `src/apis/text/text.word-sens-disambiguations.py`.

## Why ? 

At runtime, if you print the `sys.path` value, one can see that it has in its element a value `'/app/./apis/text/text/word-sens-disambiguations/bert-base-uncased'` which has nothing to do here. 

A priori, it has no impact. But still deleting this to be clean. 

The reason why this  `'/app/./apis/text/text/word-sens-disambiguations/bert-base-uncased'` appears is probably due to how `main.py` operates. See [here](https://github.com/gladiaio/gladia/tree/main/src#mainpy) for some context on `main.py`. 