### PR TITLE
feat: add all-MiniLM-L6-v2 to triton

### DIFF
--- a/src/apis/text/text/hate-speech-detections/Hate-speech-CNERG-dehatebert-mono-english/Hate-speech-CNERG-dehatebert-mono-english.py
+++ b/src/apis/text/text/hate-speech-detections/Hate-speech-CNERG-dehatebert-mono-english/Hate-speech-CNERG-dehatebert-mono-english.py
@@ -29,7 +29,7 @@ def predict(text: str) -> str:
         text, return_tensors="pt", max_length=256, padding="max_length"
     ).input_ids
 
-    client.register_new_input(shape=(1, 256), datatype="INT32")
+    client.set_input(shape=(1, 256), datatype="INT32")
     output = client(input_ids.detach().numpy().astype(np.int32))[0]
 
     out = LABELS[np.argmax(output)]

--- a/src/apis/text/text/language-detections/xlm-roberta-base-language-detection/xlm-roberta-base-language-detection.py
+++ b/src/apis/text/text/language-detections/xlm-roberta-base-language-detection/xlm-roberta-base-language-detection.py
@@ -58,7 +58,7 @@ def predict(text: str) -> List[Dict[str, Any]]:
 
     np_output = data_processing.text_to_numpy(text)
 
-    client.register_new_input(name="TEXT", shape=np_output.shape, datatype="BYTES")
+    client.set_input(name="TEXT", shape=np_output.shape, datatype="BYTES")
 
     output = softmax(client(np_output)[0][0])
 

--- a/src/apis/text/text/named-entity-recognitions/dbmdz-bert-large-cased-finetuned-conll03-english/dbmdz-bert-large-cased-finetuned-conll03-english.py
+++ b/src/apis/text/text/named-entity-recognitions/dbmdz-bert-large-cased-finetuned-conll03-english/dbmdz-bert-large-cased-finetuned-conll03-english.py
@@ -43,7 +43,7 @@ def predict(text: str) -> List[dict]:
 
     np_output = data_processing.text_to_numpy(text)
 
-    client.register_new_input(name="TEXT", shape=np_output.shape, datatype="BYTES")
+    client.set_input(name="TEXT", shape=np_output.shape, datatype="BYTES")
 
     output = client(np_output)[0].decode("utf8")
 

--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -31,7 +31,7 @@ def predict(text: str) -> str:
 
     numpy_input = data_processing.text_to_numpy(text)
 
-    client.register_new_input(name="TEXT", shape=numpy_input.shape, datatype="BYTES")
+    client.set_input(name="TEXT", shape=numpy_input.shape, datatype="BYTES")
 
     output = client(numpy_input)[0][0]
 

--- a/src/apis/text/text/similarities/all-MiniLM-L6-v2/.git_path
+++ b/src/apis/text/text/similarities/all-MiniLM-L6-v2/.git_path
@@ -1,0 +1,1 @@
+https://huggingface.co/Gladiaio/sentence-transformers_all-MiniLM-L6-v2_tensorrt

--- a/src/apis/text/text/similarities/all-MiniLM-L6-v2/all-MiniLM-L6-v2.py
+++ b/src/apis/text/text/similarities/all-MiniLM-L6-v2/all-MiniLM-L6-v2.py
@@ -8,7 +8,13 @@ from torch.nn.functional import normalize
 
 
 def cos_sim(a: list, b: list):
-    """ """
+    """
+    For two given sentences embeddings a and b, computes the cosine similarity
+
+    :param sentence_1: first sentence embeddings to compare
+    :param sentence_2: second sentence embeddings to compare
+    :return: tensor with similarity score (between 0 and 1)
+    """
     return mm(
         normalize(tensor(a), p=2, dim=1),
         normalize(tensor(b), p=2, dim=1).transpose(0, 1),

--- a/src/apis/text/text/similarities/all-MiniLM-L6-v2/all-MiniLM-L6-v2.py
+++ b/src/apis/text/text/similarities/all-MiniLM-L6-v2/all-MiniLM-L6-v2.py
@@ -1,3 +1,20 @@
+from gladia_api_utils.triton_helper import (
+    TritonClient,
+    check_if_model_needs_to_be_preloaded,
+    data_processing,
+)
+from torch import mm, tensor
+from torch.nn.functional import normalize
+
+
+def cos_sim(a: list, b: list):
+    """ """
+    return mm(
+        normalize(tensor(a), p=2, dim=1),
+        normalize(tensor(b), p=2, dim=1).transpose(0, 1),
+    )
+
+
 def predict(sentence_1: str, sentence_2: str) -> dict:
     """
     For two given sentences, say whether they are similar or not.
@@ -7,13 +24,28 @@ def predict(sentence_1: str, sentence_2: str) -> dict:
     :return: similarity score (between 0 and 1)
     """
 
-    from sentence_transformers import SentenceTransformer, util
+    MODEL_NAME = "sentence-transformers_all-MiniLM-L6-v2_tensorrt_inference"
+    MODEL_SUB_PARTS = [
+        "sentence-transformers_all-MiniLM-L6-v2_tensorrt_model",
+        "sentence-transformers_all-MiniLM-L6-v2_tensorrt_tokenize",
+    ]
 
-    model = SentenceTransformer("all-MiniLM-L6-v2")
+    client = TritonClient(
+        model_name=MODEL_NAME,
+        sub_parts=MODEL_SUB_PARTS,
+        output_name="output",
+        preload_model=check_if_model_needs_to_be_preloaded(MODEL_NAME),
+    )
 
-    embedding1 = model.encode(sentence_1, convert_to_tensor=True)
-    embedding2 = model.encode(sentence_2, convert_to_tensor=True)
+    sentence_1_preprocessed = data_processing.text_to_numpy(sentence_1)
+    sentence_2_preprocessed = data_processing.text_to_numpy(sentence_2)
 
-    cosine_scores = util.pytorch_cos_sim(embedding1, embedding2)
+    client.set_input(name="TEXT", shape=sentence_1_preprocessed.shape, datatype="BYTES")
+    sentence_1_embeddings = client(sentence_1_preprocessed)[0]
+
+    client.set_input(name="TEXT", shape=sentence_2_preprocessed.shape, datatype="BYTES")
+    sentence_2_embeddings = client(sentence_2_preprocessed)[0]
+
+    cosine_scores = cos_sim(sentence_1_embeddings, sentence_2_embeddings)
 
     return {"score": cosine_scores.item()}

--- a/src/config.json
+++ b/src/config.json
@@ -99,7 +99,8 @@
             "language-detection_papluca_xlm-roberta-base-language-detection_tensorrt_inference",
             "named-entity-recognition_dbmdz_bert-large-cased-finetuned-conll03-english_tensorrt_inference",
             "sentiment-analyses_nlptown_bert-base-multilingual-uncased-sentiment_tensorrt_inference",
-            "hate-speech-detection_bert-base-uncased-hatexplain_base_traced"
+            "hate-speech-detection_bert-base-uncased-hatexplain_base_traced",
+            "sentence-transformers_all-MiniLM-L6-v2_tensorrt_inference"
         ]
     }
 }


### PR DESCRIPTION
In this PR : 

* `text/text/similarity/&model=all-MiniLM-L6-v2` is migrated to triton
  * in `all-MiniLM-L6-v2.py`, `cos_sim()` is implemented on its own so that we do not have to import `sentence-transformers.util`, which under the hood imports import  several other packages (see [here](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/util.py))
  * the new triton model is added to the pre-loaded models via `config.json`
* `TritonClient` is modified so that several inputs can be registered
  * As a result, existing triton models that used the former way of registering inputs are adapted to the new way