### PR TITLE
ci(builder): let pytorch see all GPU

### DIFF
--- a/.github/workflows/gladia-builder.yml
+++ b/.github/workflows/gladia-builder.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Start Gladia Container
         run: | 
           docker run -d \
-          --cpus 14 --memory 32g --gpus '"device=${{steps.gpuid.outputs.gpuid}}"' --shm-size=5g \
+          --cpus 14 --memory 32g --gpus all --shm-size=5g \
           -e IS_CI="True" -e NVIDIA_VISIBLE_DEVICES=${{steps.gpuid.outputs.gpuid}} -e CUDA_VISIBLE_DEVICES=${{steps.gpuid.outputs.gpuid}} \
           -p ${{steps.gpuid.outputs.gpuid}}8000:8000 \
           -v /data/volumes/models:/tmp/gladia/models \


### PR DESCRIPTION
Pytorch need to read all GPU, even if we want it to use only one of them.