### PR TITLE
fix(nlptown-bert-base-multilingual-uncased-sentiment): unify output format to {'label':str, 'score':float}

### DIFF
--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -7,7 +7,7 @@ from gladia_api_utils.triton_helper import (
 )
 
 
-def predict(text: str) -> str:
+def predict(text: str) -> dict:
     """
     From a given, classify it between 1 (hate) and 5 (love).
 

--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -44,4 +44,7 @@ def predict(text: str) -> dict:
     rating = {0: "negative", 1: "negative", 2: "neutral", 3: "positive", 4: "positive"}
     label = rating[output.index(max(output))].upper()
 
-    return {"label": label, "score": 1} # TODO there is no confidence score from this model
+    return {
+        "label": label,
+        "score": 1,
+    }  # TODO there is no confidence score from this model

--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -47,4 +47,4 @@ def predict(text: str) -> dict:
     return {
         "label": label,
         "score": 1,
-    }  # TODO there is no confidence score from this model
+    }  # NOTE: there is no confidence score from this model

--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -43,6 +43,5 @@ def predict(text: str) -> dict:
 
     rating = {0: "negative", 1: "negative", 2: "neutral", 3: "positive", 4: "positive"}
     label = rating[output.index(max(output))].upper()
-    score = max(output)
 
-    return {"label": label, "score": score}
+    return {"label": label, "score": 1} # TODO there is no confidence score from this model

--- a/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
+++ b/src/apis/text/text/sentiment-analyses/nlptown-bert-base-multilingual-uncased-sentiment/nlptown-bert-base-multilingual-uncased-sentiment.py
@@ -42,5 +42,7 @@ def predict(text: str) -> str:
     # rating = {0: "hate", 1: "negative", 2: "neutral", 3: "positive", 4: "love"}
 
     rating = {0: "negative", 1: "negative", 2: "neutral", 3: "positive", 4: "positive"}
+    label = rating[output.index(max(output))].upper()
+    score = max(output)
 
-    return rating[output.index(max(output))]
+    return {"label": label, "score": score}


### PR DESCRIPTION
All the output of the other models was : 
{ "label": str, "score": float} exept nlptown-bert-base-multilingual-uncased-sentiment who was {"prediciton": str}
Now it is all the same.