### PR TITLE
perf(background-removal): switch background removal mobilenet model to onnx format

### DIFF
--- a/src/api_utils/gladia_api_utils/model_management.py
+++ b/src/api_utils/gladia_api_utils/model_management.py
@@ -112,4 +112,7 @@ def download_models(model_list: dict) -> dict:
             threads.append(t)
             t.start()
 
+    for t in threads:
+        t.join()
+
     return output

--- a/src/apis/image/image/background-removal-models/mobilenet/env.yaml
+++ b/src/apis/image/image/background-removal-models/mobilenet/env.yaml
@@ -1,7 +1,0 @@
-inherit:
-  - common-base
-  - image-base
-  - common-tensorflow
-
-dependencies:
-  - pip

--- a/src/apis/image/image/background-removal-models/mobilenet/mobilenet.py
+++ b/src/apis/image/image/background-removal-models/mobilenet/mobilenet.py
@@ -1,28 +1,27 @@
 import os
+import onnxruntime as ort
 
-import numpy as np
-import tensorflow.compat.v1 as tf
-from gladia_api_utils.image_management import draw_segment
-from gladia_api_utils.io import _open
-from gladia_api_utils.model_management import download_models
 from PIL import Image
+from numpy import ndarray
+from numpy import asarray as as_nparray
+from typing import Tuple
 
-tf.disable_v2_behavior()
+from gladia_api_utils.io import _open
+from gladia_api_utils.image_management import draw_segment
+from gladia_api_utils.model_management import download_models
 
-urls = {
+
+models_to_download = {
     "mobile-net": {
-        "url": "https://huggingface.co/databuzzword/mobile-net",
+        "url": "https://huggingface.co/Gladiaio/databuzzword_mobile-net_onnx",
         "output_path": "models",
     }
 }
 
-models_path = download_models(urls)
-
-# using mobile-net 30K checkpoint
-current_model_path = os.path.join(models_path["mobile-net"]["output_path"], "30000")
+models_path = download_models(models_to_download)
 
 
-def run(image: Image, fast: bool = True) -> (Image, np.ndarray):
+def run(image: Image, fast: bool = True) -> Tuple[Image.Image, ndarray]:
     """
     Call the model to return the image without its background
 
@@ -31,35 +30,19 @@ def run(image: Image, fast: bool = True) -> (Image, np.ndarray):
     :return: image without its background
     """
 
-    config = tf.ConfigProto()
-    config.gpu_options.allow_growth = True
+    del fast
 
-    sess = tf.Session(config=config)
-
-    INPUT_TENSOR_NAME = "ImageTensor:0"
     INPUT_SIZE = 513
-    FROZEN_GRAPH_NAME = "frozen_inference_graph"
-    OUTPUT_TENSOR_NAME = "SemanticPredictions:0"
+    MODEL_PATH = os.path.join(models_path["mobile-net"]["output_path"], "databuzzword_mobile-net_onnx.onnx")
+    INPUT_TENSOR_NAME = "ImageTensor:0"
 
     width, height = image.size
     resize_ratio = 1.0 * INPUT_SIZE / max(width, height)
     target_size = (int(resize_ratio * width), int(resize_ratio * height))
     resized_image = image.convert("RGB").resize(target_size, Image.ANTIALIAS)
 
-    graph_path = os.path.join(current_model_path, "frozen_inference_graph.pb")
-    slow_graph_def = tf.GraphDef.FromString(open(graph_path, "rb").read())
-
-    tf.import_graph_def(slow_graph_def, name="")
-
-    batch_seg_map = sess.run(
-        sess.graph.get_tensor_by_name(OUTPUT_TENSOR_NAME),
-        feed_dict={INPUT_TENSOR_NAME: [np.asarray(resized_image)]},
-    )
-
-    seg_map = batch_seg_map[0]
-
-    tf.reset_default_graph()
-    sess.close()
+    ort_sess = ort.InferenceSession(MODEL_PATH)
+    seg_map = ort_sess.run(None, {INPUT_TENSOR_NAME: [as_nparray(resized_image)]})[0][0]
 
     return resized_image, seg_map
 

--- a/src/apis/image/image/background-removal.py
+++ b/src/apis/image/image/background-removal.py
@@ -14,4 +14,4 @@ output = {"name": "cleaned_image", "type": "image", "example": "a.png"}
 
 router = APIRouter()
 
-TaskRouter(router=router, input=inputs, output=output, default_model="xception")
+TaskRouter(router=router, input=inputs, output=output, default_model="mobilenet")

--- a/src/env.yaml
+++ b/src/env.yaml
@@ -20,6 +20,7 @@ dependencies:
   - conda-forge::tensorflow==2.8.1
   - conda-forge::ffmpeg-python
   - conda-forge::inflect
+  - conda-forge::onnxruntime
   - pip:
     - git+https://github.com/Thytu/fastapi.git
     - -e /app/api_utils/


### PR DESCRIPTION
Exporting the model as ONNX format allows us to:
1. Remove the TF import which was time consuming (~1s)
2. Remove the env.yaml as there is no memory leak du to the tf removal

Note : Speed up the end2end call by 6x