### PR TITLE
feat(sentence-paraphraser): ramsrigouthamg-t5_sentence_paraphraser

### DIFF
--- a/src/apis/text/text/sentence-paraphraser-models/ramsrigouthamg-t5_sentence_paraphraser/.model_metadata.yaml
+++ b/src/apis/text/text/sentence-paraphraser-models/ramsrigouthamg-t5_sentence_paraphraser/.model_metadata.yaml
@@ -1,0 +1,19 @@
+api:
+  content: ''
+  tags: []
+gladia:
+  accelerator: ''
+  examples: []
+  format: ''
+  latency: ''
+huggingface:
+  link: ''
+license:
+  content: ''
+  link: ''
+  title: ''
+paper:
+  authors: []
+  citation: ''
+  link: ''
+  title: ''

--- a/src/apis/text/text/sentence-paraphraser-models/ramsrigouthamg-t5_sentence_paraphraser/ramsrigouthamg-t5_sentence_paraphraser.py
+++ b/src/apis/text/text/sentence-paraphraser-models/ramsrigouthamg-t5_sentence_paraphraser/ramsrigouthamg-t5_sentence_paraphraser.py
@@ -1,0 +1,66 @@
+import truecase
+
+from typing import Dict
+from torch import device as get_device
+from torch.cuda import is_available as is_cuda_available
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+
+def predict(context: str, top_k: int = 1) -> Dict[str, str]:
+    """
+    Generates paraphrases of the given sentence
+
+    Args:
+        context (str): The context to paraphrase
+        top_k (int): Number of sequences to return
+
+    Returns:
+        Dict[str, str]: The paraphrases of the given sentence
+    """
+
+    model_name = "ramsrigouthamg/t5_sentence_paraphraser"
+
+    device = get_device("cuda" if is_cuda_available() else "cpu")
+
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to(device)
+    model.eval()
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    text = f"paraphrase: {truecase.get_true_case(context)}</s>"
+
+    encoding = tokenizer.encode_plus(
+        text, max_length=128, padding="max_length", return_tensors="pt"
+    )
+    input_ids, attention_mask = (
+        encoding["input_ids"].to(device),
+        encoding["attention_mask"].to(device),
+    )
+
+    beam_outputs = model.generate(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        max_new_tokens=128,
+        early_stopping=True,
+        num_beams=15,
+        num_beam_groups=5,
+        num_return_sequences=top_k,
+        diversity_penalty=0.70,
+    )
+
+    output = []
+
+    for beam_output in beam_outputs:
+        sent = tokenizer.decode(
+            beam_output, skip_special_tokens=True, clean_up_tokenization_spaces=True
+        )
+        output.append(sent.replace("paraphrasedoutput: ", ""))
+
+    del tokenizer
+    del model
+    del encoding
+    del beam_outputs
+
+    return {"prediction": output[0], "prediction_raw": output}
+
+print(predict("I like to eat potato while driving home."))

--- a/src/apis/text/text/sentence-paraphraser.py
+++ b/src/apis/text/text/sentence-paraphraser.py
@@ -18,5 +18,5 @@ TaskRouter(
     router=router,
     input=inputs,
     output=output,
-    default_model="ramsrigouthamg-t5-large-paraphraser-diverse-high-quality",
+    default_model="ramsrigouthamg-t5_sentence_paraphraser",
 )


### PR DESCRIPTION
* add new sentence-paraphraser model `ramsrigouthamg-t5_sentence_paraphraser`
* changed default  sentence-paraphraser model to `ramsrigouthamg-t5_sentence_paraphraser`

`ramsrigouthamg-t5_sentence_paraphraser` is ~25% faster compared to `ramsrigouthamg-t5-large-paraphraser-diverse-high-quality`.

For further improving the inference time we will have to pin the model into memory.
(This model takes ~15s end2end)

@jsoto-gladia What would be a "good enough" inference time?