### PR TITLE
fix(TaskRouter): handle invalid url (#838)

### DIFF
--- a/src/api_utils/gladia_api_utils/submodules.py
+++ b/src/api_utils/gladia_api_utils/submodules.py
@@ -938,8 +938,11 @@ async def clean_kwargs_based_on_router_inputs(
 
                 dummy_header = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "}
 
-                req = urllib.request.Request(url=url, headers=dummy_header)
-                kwargs[input_name] = urlopen(req).read()
+                try:
+                    req = urllib.request.Request(url=url, headers=dummy_header)
+                    kwargs[input_name] = urlopen(req).read()
+                except urllib.error.URLError:
+                    return ({}, False, "Couldn't reach provided url.")
 
             # if not a bytes either, file is missing
             elif not isinstance(


### PR DESCRIPTION
Fixes #838 

If `urlopen` failed, `clean_kwargs_based_on_router_inputs` return a `success=False` value

Signed-off-by: Thytu <valentin.de-matos@epitech.eu>