### PR TITLE
feat: config can specify model

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -188,7 +188,9 @@ def __add_router(module: ModuleType, module_path: str) -> None:
     module_task = to_task_name(module_task)
     module_config = config["active_tasks"][module_input][module_output]
 
-    active_task_list = set(map(lambda each: to_task_name(each.split("?")[0]), module_config))
+    active_task_list = set(
+        map(lambda each: to_task_name(each.split("?")[0]), module_config)
+    )
 
     if ("NONE" not in active_task_list and "NONE" not in module_config) and (
         module_task in active_task_list or "*" in module_config

--- a/src/main.py
+++ b/src/main.py
@@ -185,10 +185,10 @@ def __add_router(module: ModuleType, module_path: str) -> None:
         apis_folder_name, ""
     )[1:].split(".")
 
-    module_task = to_task_name(module_task).upper()
+    module_task = to_task_name(module_task)
     module_config = config["active_tasks"][module_input][module_output]
 
-    active_task_list = list(map(lambda each: to_task_name(each).upper(), module_config))
+    active_task_list = set(map(lambda each: to_task_name(each.split("?")[0]), module_config))
 
     if ("NONE" not in active_task_list and "NONE" not in module_config) and (
         module_task in active_task_list or "*" in module_config


### PR DESCRIPTION
## What

In the `config.json` you can now do: `"image":["background-removal?model=mobilenet"]`.
Note : This would change nothing in the behaviour (you could still target `xception` in this example).

@jqueguiner  if you have any suggestion, feel free to let me know.

## Why

We may want to have an instance `I_A` handling only model `M_A` and an instance `I_B` handling only model `M_B`.
This redirection between `I_A` and `I_B` is based on the `config.json` file. Thus we need to be able to specify the model.

Again, `gladia/gladia` is agnostic of this behaviour, it change nothing here, only on the routing.