### PR TITLE
ci(rollout): sequentially wait for rollout success

### DIFF
--- a/.github/workflows/gladia-latest-deploy.yml
+++ b/.github/workflows/gladia-latest-deploy.yml
@@ -154,6 +154,10 @@ jobs:
           curl -L -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/${KVERSION}/bin/linux/amd64/kubectl
           chmod +x /tmp/kubectl
           /tmp/kubectl rollout restart deployment aipi-heavy -n $KNS
+          /tmp/kubectl rollout status deployment aipi-heavy --timeout=20m -n $KNS
           /tmp/kubectl rollout restart deployment aipi-slow -n $KNS
+          /tmp/kubectl rollout status deployment aipi-slow --timeout=20m -n $KNS
           /tmp/kubectl rollout restart deployment aipi-fast -n $KNS
+          /tmp/kubectl rollout status deployment aipi-fast --timeout=20m -n $KNS
           /tmp/kubectl rollout restart deployment aipi-triton-client -n $KNS
+          /tmp/kubectl rollout status deployment aipi-triton-client --timeout=20m -n $KNS


### PR DESCRIPTION
Avoid restart all at once. 
Will work better once healthcheck available.