### PR TITLE
ci(pypi): delegate to GH as workaround

### DIFF
--- a/.github/workflows/upload-api-utils-to-pypi.yaml
+++ b/.github/workflows/upload-api-utils-to-pypi.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Check changed files
     outputs:
       update_api_utils: ${{ steps.changed-api-utils.outputs.any_changed }}
-    runs-on: [self-hosted, build, ephemeral]
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
   upload:
     if: ${{ (needs.check_if_need_to_rebuild.outputs.update_api_utils  == 'true') }}
 
-    runs-on: [self-hosted, build, ephemeral]
+    runs-on: ubuntu-latest
 
     steps:
       - name: build dist


### PR DESCRIPTION
the changed files action is probably failing because our runners have some path in read-only or something related (to be investigated).
This is a simple action, we can delegate to the GH runner until we fix this.