### PR TITLE
ci(docker): always prune old data a after successful build

### DIFF
--- a/.github/workflows/gladia-builder.yml
+++ b/.github/workflows/gladia-builder.yml
@@ -14,6 +14,7 @@ env:
   DOCKER_BUILD_ARGS_GLADIA_BASE_IMAGE: ${DOCKER_GLADIA_FQDN}/gladia/base:latest
   DOCKER_GLADIA_BUILD_NEEDED: false
   DOCKER_BASE_BUILD_NEEDED: false
+  DOCKER_RETENTION_HOURS: 72
   TEST_DEFAULT_MODELS_ONLY: '--default-models-only'
   TEST_DEFAULT_INPUTS_ONLY: '--default-inputs-only'
   TEST_STOP_AT_FAIL: '-x'
@@ -139,6 +140,9 @@ jobs:
               CMD ["/app/run_server.sh"]
           EOF
           } && docker push ${DOCKER_GLADIA_FQDN}/gladia/gladia:${{env.DOCKER_BUILD_TAG}}
+
+      - name: Docker cleanup
+        run: docker system prune -f -a --filter "until=${{env.DOCKER_RETENTION_HOURS}}h"
 
   test:
     needs: build


### PR DESCRIPTION
Also testing the persistent model directory for tests.