### PR TITLE
fix(speaker-diarization): return if pipeline loading fails

### DIFF
--- a/src/apis/audio/text/speaker-diarization/pyannote-speaker_diarization/pyannote-speaker_diarization.py
+++ b/src/apis/audio/text/speaker-diarization/pyannote-speaker_diarization/pyannote-speaker_diarization.py
@@ -39,6 +39,11 @@ def predict(audio: str) -> Dict[str, str]:
     except Exception as e:
         logger.error(error_msg.format(e=e))
 
+        return {
+            "prediction": "Error while loading pipeline",
+            "prediction_raw": error_msg.format(e=e),
+        }
+
     audio_segment = AudioSegment.from_file(audio)
 
     tmp_file = get_tmp_filename()


### PR DESCRIPTION
The model crashs when the first try/catch fails as pipeline is not defined.

Signed-off-by: Thytu <vdmatos@gladia.io>